### PR TITLE
feat: export public runtime hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,20 +65,27 @@ Use Svelte's native head support for component-local metadata:
 
 ## 🧭 Reading Page Context
 
-`vike-svelte` currently exposes the Svelte context keys through `vike-svelte/context`.
+`vike-svelte` exposes public hooks for reading Vike data from Svelte components.
 
 ```svelte
 <script>
-  import { getContext } from 'svelte'
-  import { PageKey } from 'vike-svelte/context'
+  import { usePageContext } from 'vike-svelte/usePageContext'
 
-  const pageContext = getContext(PageKey)
+  const pageContext = usePageContext()
 </script>
 
 <p>{pageContext.urlPathname}</p>
 ```
 
-Public hook exports such as `vike-svelte/usePageContext` and `vike-svelte/useData` are tracked in [issue #17](https://github.com/brandonxiang/vike-svelte/issues/17).
+Use `useData()` when a page only needs `pageContext.data`.
+
+```svelte
+<script>
+  import { useData } from 'vike-svelte/useData'
+
+  const data = useData()
+</script>
+```
 
 ## 🧩 Client-Only Components
 
@@ -126,7 +133,7 @@ The renderer currently declares these Vike config entries:
 
 | Area | Issue |
 | --- | --- |
-| Public runtime hooks | [#17](https://github.com/brandonxiang/vike-svelte/issues/17) |
+| Public runtime hooks | `usePageContext()` and `useData()` are supported. See [#17](https://github.com/brandonxiang/vike-svelte/issues/17) |
 | Dynamic head and config APIs | [#18](https://github.com/brandonxiang/vike-svelte/issues/18) |
 | Renderer output for declared config | [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
 | Cumulative `Layout` and `Wrapper` behavior | [#20](https://github.com/brandonxiang/vike-svelte/issues/20) |

--- a/examples/full/components/Link.svelte
+++ b/examples/full/components/Link.svelte
@@ -1,7 +1,5 @@
 <script>
-  import { getContext } from "svelte"
-  
-  import { PageKey } from 'vike-svelte/context'
+  import { usePageContext } from 'vike-svelte/usePageContext'
   
   /**
    * @typedef {Object} Props
@@ -14,7 +12,7 @@
   
   let isActive = $state(false)
   
-  const pageContext = getContext(PageKey);
+  const pageContext = usePageContext();
   
   $effect(() => {
     const { urlPathname } = pageContext

--- a/examples/full/pages/_error/+Page.svelte
+++ b/examples/full/pages/_error/+Page.svelte
@@ -1,6 +1,5 @@
 <script>
- import { PageKey } from 'vike-svelte/context' 
- import { getContext } from 'svelte'
+ import { usePageContext } from 'vike-svelte/usePageContext'
   /**
    * @typedef {Object} Props
    * @property {boolean} is404
@@ -10,7 +9,7 @@
   /** @type {Props} */
   // let { is404, errorInfo = '' } = $props();
 
-  const { is404, errorInfo= '' } = getContext(PageKey);
+  const { is404, errorInfo= '' } = usePageContext();
 </script>
 
 {#if is404}

--- a/examples/full/pages/star-wars/@id/+Page.svelte
+++ b/examples/full/pages/star-wars/@id/+Page.svelte
@@ -1,9 +1,7 @@
 <script>
-    import { getContext } from 'svelte';
-    import { PageKey } from 'vike-svelte/context';
+    import { useData } from 'vike-svelte/useData';
 
-    const pageContext = getContext(PageKey);
-    const { data } = pageContext;
+    const data = useData();
     export let movie = data;
 </script>
 

--- a/examples/full/pages/star-wars/index/+Page.svelte
+++ b/examples/full/pages/star-wars/index/+Page.svelte
@@ -1,9 +1,7 @@
 <script>
-    import { getContext } from 'svelte';
-    import { PageKey } from 'vike-svelte/context';
+    import { useData } from 'vike-svelte/useData';
 
-    const pageContext = getContext(PageKey);
-    const { data } = pageContext;
+    const data = useData();
     /**
      * @type {import('../types').MovieDetails[]}
      */

--- a/examples/minimal/components/Link.svelte
+++ b/examples/minimal/components/Link.svelte
@@ -1,6 +1,5 @@
 <script>
-  import { getContext } from 'svelte'
-  import { PageKey } from 'vike-svelte/context'
+  import { usePageContext } from 'vike-svelte/usePageContext'
 
   /**
    * @typedef {Object} Props
@@ -13,7 +12,7 @@
 
   let isActive = $state(false)
 
-  const pageContext = getContext(PageKey)
+  const pageContext = usePageContext()
 
   $effect(() => {
     const { urlPathname } = pageContext

--- a/packages/vike-svelte/README.md
+++ b/packages/vike-svelte/README.md
@@ -65,20 +65,27 @@ Use Svelte's native head support for component-local metadata:
 
 ## 🧭 Reading Page Context
 
-`vike-svelte` currently exposes the Svelte context keys through `vike-svelte/context`.
+`vike-svelte` exposes public hooks for reading Vike data from Svelte components.
 
 ```svelte
 <script>
-  import { getContext } from 'svelte'
-  import { PageKey } from 'vike-svelte/context'
+  import { usePageContext } from 'vike-svelte/usePageContext'
 
-  const pageContext = getContext(PageKey)
+  const pageContext = usePageContext()
 </script>
 
 <p>{pageContext.urlPathname}</p>
 ```
 
-Public hook exports such as `vike-svelte/usePageContext` and `vike-svelte/useData` are tracked in [issue #17](https://github.com/brandonxiang/vike-svelte/issues/17).
+Use `useData()` when a page only needs `pageContext.data`.
+
+```svelte
+<script>
+  import { useData } from 'vike-svelte/useData'
+
+  const data = useData()
+</script>
+```
 
 ## 🧩 Client-Only Components
 
@@ -126,7 +133,7 @@ The renderer currently declares these Vike config entries:
 
 | Area | Issue |
 | --- | --- |
-| Public runtime hooks | [#17](https://github.com/brandonxiang/vike-svelte/issues/17) |
+| Public runtime hooks | `usePageContext()` and `useData()` are supported. See [#17](https://github.com/brandonxiang/vike-svelte/issues/17) |
 | Dynamic head and config APIs | [#18](https://github.com/brandonxiang/vike-svelte/issues/18) |
 | Renderer output for declared config | [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
 | Cumulative `Layout` and `Wrapper` behavior | [#20](https://github.com/brandonxiang/vike-svelte/issues/20) |

--- a/packages/vike-svelte/hooks/useData.js
+++ b/packages/vike-svelte/hooks/useData.js
@@ -1,7 +1,11 @@
-import { getContext } from "svelte";
+import { getContext } from 'svelte'
+import { DataKey } from '../renderer/utils/context.js'
 
-export const key = 'vike-svelte:useData';
-
+/**
+ * Read `pageContext.data` from Svelte component context.
+ *
+ * @returns {unknown}
+ */
 export function useData() {
-    return getContext(key);
+  return getContext(DataKey)
 }

--- a/packages/vike-svelte/hooks/usePageContext.js
+++ b/packages/vike-svelte/hooks/usePageContext.js
@@ -1,0 +1,11 @@
+import { getContext } from 'svelte'
+import { PageKey } from '../renderer/utils/context.js'
+
+/**
+ * Read the current Vike page context from Svelte component context.
+ *
+ * @returns {import('vike/types').PageContext | import('vike/types').PageContextClient}
+ */
+export function usePageContext() {
+  return getContext(PageKey)
+}

--- a/packages/vike-svelte/package.json
+++ b/packages/vike-svelte/package.json
@@ -7,6 +7,8 @@
   "exports": {
     "./config": "./renderer/+config.js",
     "./clientOnly": "./components/ClientOnly.svelte",
+    "./useData": "./hooks/useData.js",
+    "./usePageContext": "./hooks/usePageContext.js",
     "./__internal/integration/onRenderHtml": "./renderer/integration/onRenderHtml.js",
     "./__internal/integration/onRenderClient": "./renderer/integration/onRenderClient.js",
     "./context": "./renderer/utils/context.js"
@@ -33,6 +35,12 @@
     "*": {
       "config": [
         "./dist/renderer/+config.d.ts"
+      ],
+      "useData": [
+        "./dist/hooks/useData.d.ts"
+      ],
+      "usePageContext": [
+        "./dist/hooks/usePageContext.d.ts"
       ],
       "__internal/integration/onRenderHtml": [
         "./dist/renderer/integration/onRenderHtml.d.ts"

--- a/packages/vike-svelte/renderer/integration/onRenderClient.js
+++ b/packages/vike-svelte/renderer/integration/onRenderClient.js
@@ -2,7 +2,7 @@ export { onRenderClient }
 
 import Empty from '../../components/Empty.svelte';
 import PassThrough from '../../components/PassThrough.svelte'
-import { PageKey } from '../utils/context.js'
+import { DataKey, PageKey } from '../utils/context.js'
 import { hydrate, mount, unmount } from 'svelte';
 
 /**
@@ -28,6 +28,10 @@ function onRenderClient(pageContext) {
   /** @type {import('svelte').Component} */
   const Layout = config.Layout?.[0] ?? PassThrough;
   const Page = pageContext.Page ?? Empty;
+  const context = new Map([
+    [PageKey, pageContext],
+    [DataKey, pageContext.data],
+  ])
 
 
 
@@ -38,7 +42,7 @@ function onRenderClient(pageContext) {
     if (pageContext.isHydration) {
       root = hydrate(Layout, {
         target,
-        context: new Map([[PageKey, pageContext]]),
+        context,
         props: {
           Page,
         }
@@ -46,7 +50,7 @@ function onRenderClient(pageContext) {
     } else {
       root = mount(Layout, {
         target,
-        context: new Map([[PageKey, pageContext]]),
+        context,
         props: {
           Page,
         }

--- a/packages/vike-svelte/renderer/integration/onRenderHtml.js
+++ b/packages/vike-svelte/renderer/integration/onRenderHtml.js
@@ -5,7 +5,7 @@ import { escapeInject, dangerouslySkipEscape } from 'vike/server'
 import PassThrough from '../../components/PassThrough.svelte'
 import Empty from '../../components/Empty.svelte'
 import { getTitle } from '../getTitle.js'
-import { PageKey } from '../utils/context.js'
+import { DataKey, PageKey } from '../utils/context.js'
 import { render } from 'svelte/server'
 
 /**
@@ -20,7 +20,12 @@ function onRenderHtml(pageContext) {
   const Layout = config.Layout?.[0] ?? PassThrough;
   const Page = pageContext.Page ?? Empty;
 
-  const app = render(Layout, { context: new Map([[PageKey, pageContext]]), props: { Page } })
+  const context = new Map([
+    [PageKey, pageContext],
+    [DataKey, pageContext.data],
+  ])
+
+  const app = render(Layout, { context, props: { Page } })
   const { body, head } = app
 
   const title = getTitle(pageContext)


### PR DESCRIPTION
## Summary

- Export `vike-svelte/usePageContext` and `vike-svelte/useData` from the package.
- Inject `pageContext.data` into Svelte render context for SSR and client rendering.
- Update examples and README docs to use the public hook import paths instead of raw context keys.

Closes #17.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test` in `examples/full`
- `pnpm run test` in `examples/minimal`
- `pnpm run build` in `examples/full`
- `pnpm run build` in `examples/minimal`
- `npm pack --dry-run --json` in `packages/vike-svelte`
- `git diff --check`