### PR TITLE
feat: add dynamic config API

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,34 @@ Use Svelte's native head support for component-local metadata:
 
 Public hook exports such as `vike-svelte/usePageContext` and `vike-svelte/useData` are tracked in [issue #17](https://github.com/brandonxiang/vike-svelte/issues/17).
 
+## 🏷️ Dynamic Page Config
+
+Use `useConfig()` when a Svelte component needs to set Vike-backed document metadata during SSR and client navigation.
+
+```svelte
+<script>
+  import { useConfig } from 'vike-svelte/useConfig'
+
+  useConfig({
+    title: 'Dashboard',
+    description: 'Team dashboard',
+    lang: 'en'
+  })
+</script>
+```
+
+For declarative component usage, import `vike-svelte/Config`.
+
+```svelte
+<script>
+  import Config from 'vike-svelte/Config'
+</script>
+
+<Config title="Dashboard" description="Team dashboard" />
+```
+
+Use Svelte's `<svelte:head>` for component-local tags that do not need to flow through Vike config. Use `useConfig()` or `<Config />` for title, description, language, and favicon values that should be visible to the renderer.
+
 ## 🧩 Client-Only Components
 
 Use `vike-svelte/clientOnly` when a component depends on browser APIs and should not render during SSR.
@@ -127,7 +155,7 @@ The renderer currently declares these Vike config entries:
 | Area | Issue |
 | --- | --- |
 | Public runtime hooks | [#17](https://github.com/brandonxiang/vike-svelte/issues/17) |
-| Dynamic head and config APIs | [#18](https://github.com/brandonxiang/vike-svelte/issues/18) |
+| Dynamic head and config APIs | `useConfig()` and `<Config />` are supported. See [#18](https://github.com/brandonxiang/vike-svelte/issues/18) |
 | Renderer output for declared config | [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
 | Cumulative `Layout` and `Wrapper` behavior | [#20](https://github.com/brandonxiang/vike-svelte/issues/20) |
 | Streaming support decision | [#21](https://github.com/brandonxiang/vike-svelte/issues/21) |

--- a/examples/minimal/pages/index/+Page.svelte
+++ b/examples/minimal/pages/index/+Page.svelte
@@ -1,5 +1,13 @@
 <script>
   import Counter from '../../components/Counter.svelte'
+  import { useConfig } from 'vike-svelte/useConfig'
+
+  useConfig({
+    title: 'Welcome to Vike Svelte',
+    description: 'A Svelte page using vike-svelte dynamic config',
+    lang: 'en',
+  })
+
   let title = $state('Welcome');
 
 </script>

--- a/packages/vike-svelte/README.md
+++ b/packages/vike-svelte/README.md
@@ -80,6 +80,34 @@ Use Svelte's native head support for component-local metadata:
 
 Public hook exports such as `vike-svelte/usePageContext` and `vike-svelte/useData` are tracked in [issue #17](https://github.com/brandonxiang/vike-svelte/issues/17).
 
+## 🏷️ Dynamic Page Config
+
+Use `useConfig()` when a Svelte component needs to set Vike-backed document metadata during SSR and client navigation.
+
+```svelte
+<script>
+  import { useConfig } from 'vike-svelte/useConfig'
+
+  useConfig({
+    title: 'Dashboard',
+    description: 'Team dashboard',
+    lang: 'en'
+  })
+</script>
+```
+
+For declarative component usage, import `vike-svelte/Config`.
+
+```svelte
+<script>
+  import Config from 'vike-svelte/Config'
+</script>
+
+<Config title="Dashboard" description="Team dashboard" />
+```
+
+Use Svelte's `<svelte:head>` for component-local tags that do not need to flow through Vike config. Use `useConfig()` or `<Config />` for title, description, language, and favicon values that should be visible to the renderer.
+
 ## 🧩 Client-Only Components
 
 Use `vike-svelte/clientOnly` when a component depends on browser APIs and should not render during SSR.
@@ -127,7 +155,7 @@ The renderer currently declares these Vike config entries:
 | Area | Issue |
 | --- | --- |
 | Public runtime hooks | [#17](https://github.com/brandonxiang/vike-svelte/issues/17) |
-| Dynamic head and config APIs | [#18](https://github.com/brandonxiang/vike-svelte/issues/18) |
+| Dynamic head and config APIs | `useConfig()` and `<Config />` are supported. See [#18](https://github.com/brandonxiang/vike-svelte/issues/18) |
 | Renderer output for declared config | [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
 | Cumulative `Layout` and `Wrapper` behavior | [#20](https://github.com/brandonxiang/vike-svelte/issues/20) |
 | Streaming support decision | [#21](https://github.com/brandonxiang/vike-svelte/issues/21) |

--- a/packages/vike-svelte/components/Config.svelte
+++ b/packages/vike-svelte/components/Config.svelte
@@ -1,0 +1,16 @@
+<script>
+  import { useConfig } from '../hooks/useConfig.js'
+
+  /**
+   * @typedef {Object} Props
+   * @property {string | undefined} [title]
+   * @property {string | undefined} [description]
+   * @property {string | undefined} [lang]
+   * @property {string | undefined} [favicon]
+   */
+
+  /** @type {Props} */
+  const props = $props()
+
+  useConfig(props)
+</script>

--- a/packages/vike-svelte/hooks/useConfig.js
+++ b/packages/vike-svelte/hooks/useConfig.js
@@ -1,0 +1,62 @@
+import { BROWSER } from 'esm-env'
+import { getContext } from 'svelte'
+import { PageKey } from '../renderer/utils/context.js'
+
+/**
+ * Update page-level Vike config from a Svelte component.
+ *
+ * This runs during SSR and on the client. The renderer reads
+ * `pageContext._configFromHook` after Svelte has rendered the page.
+ *
+ * @param {{ title?: string, description?: string, lang?: string, favicon?: string }} config
+ */
+export function useConfig(config) {
+  /** @type {*} */
+  const pageContext = getContext(PageKey)
+  pageContext._configFromHook = {
+    ...pageContext._configFromHook,
+    ...config,
+  }
+
+  if (BROWSER) {
+    applyClientConfig(config)
+  }
+}
+
+/**
+ * @param {{ title?: string, description?: string, lang?: string, favicon?: string }} config
+ */
+function applyClientConfig(config) {
+  if (typeof config.title === 'string') {
+    document.title = config.title
+  }
+  if (typeof config.lang === 'string') {
+    document.documentElement.lang = config.lang
+  }
+  if (typeof config.description === 'string') {
+    upsertElement('meta[name="description"]', 'meta', (element) => {
+      element.setAttribute('name', 'description')
+      element.setAttribute('content', config.description || '')
+    })
+  }
+  if (typeof config.favicon === 'string') {
+    upsertElement('link[rel="icon"]', 'link', (element) => {
+      element.setAttribute('rel', 'icon')
+      element.setAttribute('href', config.favicon || '')
+    })
+  }
+}
+
+/**
+ * @param {string} selector
+ * @param {string} tagName
+ * @param {(element: Element) => void} update
+ */
+function upsertElement(selector, tagName, update) {
+  let element = document.head.querySelector(selector)
+  if (!element) {
+    element = document.createElement(tagName)
+    document.head.appendChild(element)
+  }
+  update(element)
+}

--- a/packages/vike-svelte/package.json
+++ b/packages/vike-svelte/package.json
@@ -6,7 +6,9 @@
   "types": "./dist/renderer/+config.d.ts",
   "exports": {
     "./config": "./renderer/+config.js",
+    "./Config": "./components/Config.svelte",
     "./clientOnly": "./components/ClientOnly.svelte",
+    "./useConfig": "./hooks/useConfig.js",
     "./__internal/integration/onRenderHtml": "./renderer/integration/onRenderHtml.js",
     "./__internal/integration/onRenderClient": "./renderer/integration/onRenderClient.js",
     "./context": "./renderer/utils/context.js"
@@ -33,6 +35,9 @@
     "*": {
       "config": [
         "./dist/renderer/+config.d.ts"
+      ],
+      "useConfig": [
+        "./dist/hooks/useConfig.d.ts"
       ],
       "__internal/integration/onRenderHtml": [
         "./dist/renderer/integration/onRenderHtml.d.ts"

--- a/packages/vike-svelte/renderer/getTitle.js
+++ b/packages/vike-svelte/renderer/getTitle.js
@@ -8,6 +8,14 @@ import { isCallable } from './utils/isCallable.js'
  * @returns { null | string }
  */
 function getTitle(pageContext) {
+  const configFromHook = /** @type {*} */ (pageContext)._configFromHook
+  const titleFromHook = configFromHook?.title
+  if (titleFromHook) {
+    if (typeof titleFromHook !== 'string') {
+      throw new Error('pageContext._configFromHook.title should be a string')
+    }
+    return titleFromHook
+  }
   if (pageContext.title) {
     if (typeof pageContext.title !== 'string') {
       throw new Error('pageContext.title should be a string')

--- a/packages/vike-svelte/renderer/integration/onRenderHtml.js
+++ b/packages/vike-svelte/renderer/integration/onRenderHtml.js
@@ -26,13 +26,15 @@ function onRenderHtml(pageContext) {
   const title = getTitle(pageContext)
   const titleTag = !title ? '' : escapeInject`<title>${title}</title>`
 
-  const { description } = config
+  const configFromHook = /** @type {*} */ (pageContext)._configFromHook ?? {}
+
+  const description = configFromHook.description ?? config.description
   const descriptionTag = !description ? '' : escapeInject`<meta name="description" content="${description}" />`
 
-  const { favicon } = config
+  const favicon = configFromHook.favicon ?? config.favicon
   const faviconTag = !favicon ? '' : escapeInject`<link rel="icon" href="${favicon}" />`
 
-  const lang = config.lang || 'en'
+  const lang = configFromHook.lang ?? config.lang ?? 'en'
 
   const documentHtml = escapeInject`<!DOCTYPE html>
       <html lang="${lang}">


### PR DESCRIPTION
## Summary

- Add `vike-svelte/useConfig` and `vike-svelte/Config` for component-driven metadata updates.
- Apply hook-provided title, description, lang, and favicon during SSR and client navigation.
- Document the API and add a minimal example page using dynamic config.

Closes #18.

## Verification

- `pnpm run build`
- `pnpm run test` in `examples/minimal`
- `pnpm run build` in `examples/minimal`
- `npm pack --dry-run --json` in `packages/vike-svelte`
- `git diff --check`