### PR TITLE
feat: render declared HTML config

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,20 @@ The renderer currently declares these Vike config entries:
 | `bodyAttributes` | Declared, renderer output tracked in [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
 | `onAfterRenderClient` | Declared for client runtime hooks |
 
+Example:
+
+```js
+export default {
+  viewport: 'width=device-width, initial-scale=1',
+  htmlAttributes: {
+    'data-renderer': 'vike-svelte'
+  },
+  bodyAttributes: {
+    'data-app-shell': 'default'
+  }
+}
+```
+
 ## 🧱 Parity With vike-react
 
 `vike-svelte` is not yet feature-equivalent with `vike-react`. The current work is split into executable issues:
@@ -128,7 +142,7 @@ The renderer currently declares these Vike config entries:
 | --- | --- |
 | Public runtime hooks | [#17](https://github.com/brandonxiang/vike-svelte/issues/17) |
 | Dynamic head and config APIs | [#18](https://github.com/brandonxiang/vike-svelte/issues/18) |
-| Renderer output for declared config | [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
+| Renderer output for declared config | `viewport`, `htmlAttributes`, and `bodyAttributes` are supported. See [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
 | Cumulative `Layout` and `Wrapper` behavior | [#20](https://github.com/brandonxiang/vike-svelte/issues/20) |
 | Streaming support decision | [#21](https://github.com/brandonxiang/vike-svelte/issues/21) |
 | Client-only static removal behavior | [#22](https://github.com/brandonxiang/vike-svelte/issues/22) |

--- a/examples/minimal/pages/+config.js
+++ b/examples/minimal/pages/+config.js
@@ -9,6 +9,13 @@ import logoUrl from '../assets/logo.svg'
 export default {
   title: 'My Vike + Svelte App',
   description: 'Demo showcasing Vike + Svelte',
+  viewport: 'width=device-width, initial-scale=1',
+  htmlAttributes: {
+    'data-renderer': 'vike-svelte',
+  },
+  bodyAttributes: {
+    'data-app-shell': 'minimal',
+  },
   favicon: logoUrl,
   Layout,
   extends: vikeSvelte

--- a/packages/vike-svelte/README.md
+++ b/packages/vike-svelte/README.md
@@ -120,6 +120,20 @@ The renderer currently declares these Vike config entries:
 | `bodyAttributes` | Declared, renderer output tracked in [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
 | `onAfterRenderClient` | Declared for client runtime hooks |
 
+Example:
+
+```js
+export default {
+  viewport: 'width=device-width, initial-scale=1',
+  htmlAttributes: {
+    'data-renderer': 'vike-svelte'
+  },
+  bodyAttributes: {
+    'data-app-shell': 'default'
+  }
+}
+```
+
 ## 🧱 Parity With vike-react
 
 `vike-svelte` is not yet feature-equivalent with `vike-react`. The current work is split into executable issues:
@@ -128,7 +142,7 @@ The renderer currently declares these Vike config entries:
 | --- | --- |
 | Public runtime hooks | [#17](https://github.com/brandonxiang/vike-svelte/issues/17) |
 | Dynamic head and config APIs | [#18](https://github.com/brandonxiang/vike-svelte/issues/18) |
-| Renderer output for declared config | [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
+| Renderer output for declared config | `viewport`, `htmlAttributes`, and `bodyAttributes` are supported. See [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
 | Cumulative `Layout` and `Wrapper` behavior | [#20](https://github.com/brandonxiang/vike-svelte/issues/20) |
 | Streaming support decision | [#21](https://github.com/brandonxiang/vike-svelte/issues/21) |
 | Client-only static removal behavior | [#22](https://github.com/brandonxiang/vike-svelte/issues/22) |

--- a/packages/vike-svelte/renderer/integration/onRenderHtml.js
+++ b/packages/vike-svelte/renderer/integration/onRenderHtml.js
@@ -6,6 +6,7 @@ import PassThrough from '../../components/PassThrough.svelte'
 import Empty from '../../components/Empty.svelte'
 import { getTitle } from '../getTitle.js'
 import { PageKey } from '../utils/context.js'
+import { mergeAttributes, serializeAttributes } from '../utils/htmlAttributes.js'
 import { render } from 'svelte/server'
 
 /**
@@ -29,21 +30,30 @@ function onRenderHtml(pageContext) {
   const { description } = config
   const descriptionTag = !description ? '' : escapeInject`<meta name="description" content="${description}" />`
 
+  const { viewport } = config
+  const viewportTag = !viewport ? '' : escapeInject`<meta name="viewport" content="${viewport}" />`
+
   const { favicon } = config
   const faviconTag = !favicon ? '' : escapeInject`<link rel="icon" href="${favicon}" />`
 
   const lang = config.lang || 'en'
+  const htmlAttributes = serializeAttributes({
+    ...mergeAttributes(config.htmlAttributes),
+    lang,
+  })
+  const bodyAttributes = serializeAttributes(mergeAttributes(config.bodyAttributes))
 
   const documentHtml = escapeInject`<!DOCTYPE html>
-      <html lang="${lang}">
+      <html ${dangerouslySkipEscape(htmlAttributes)}>
         <head>
           <meta charset="UTF-8" />
           ${faviconTag}
           ${titleTag}
           ${descriptionTag}
+          ${viewportTag}
           ${dangerouslySkipEscape(head)}
         </head>
-        <body>
+        <body ${dangerouslySkipEscape(bodyAttributes)}>
           <div id="root">
             ${dangerouslySkipEscape(body)}
           </div>

--- a/packages/vike-svelte/renderer/types.d.ts
+++ b/packages/vike-svelte/renderer/types.d.ts
@@ -19,6 +19,8 @@ declare global {
       title?: string
       /** &lt;meta name="description" content="${description}" /> */
       description?: string
+      /** &lt;meta name="viewport" content="${viewport}" /> */
+      viewport?: string
       /** &lt;link rel="icon" href="${favicon}" /> */
       favicon?: string
       /** &lt;html lang="${lang}">
@@ -39,6 +41,10 @@ declare global {
        *
        */
       ssr?: boolean
+      /** Additional attributes rendered on the root &lt;html> element. */
+      htmlAttributes?: Record<string, string | number | boolean | null | undefined>
+      /** Additional attributes rendered on the &lt;body> element. */
+      bodyAttributes?: Record<string, string | number | boolean | null | undefined>
     }
   }
 }
@@ -55,6 +61,8 @@ declare global {
       title?: string
       /** &lt;meta name="description" content="${description}" /> */
       description?: string
+      /** &lt;meta name="viewport" content="${viewport}" /> */
+      viewport?: string
       /** &lt;link rel="icon" href="${favicon}" /> */
       favicon?: string
       /** &lt;html lang="${lang}">
@@ -75,6 +83,10 @@ declare global {
        *
        */
       ssr?: boolean
+      /** Additional attributes rendered on the root &lt;html> element. */
+      htmlAttributes?: Record<string, string | number | boolean | null | undefined>
+      /** Additional attributes rendered on the &lt;body> element. */
+      bodyAttributes?: Record<string, string | number | boolean | null | undefined>
     }
   }
 }

--- a/packages/vike-svelte/renderer/utils/htmlAttributes.js
+++ b/packages/vike-svelte/renderer/utils/htmlAttributes.js
@@ -1,0 +1,53 @@
+export { mergeAttributes, serializeAttributes }
+
+/**
+ * @param {Record<string, unknown> | Array<Record<string, unknown>> | undefined} value
+ * @returns {Record<string, unknown>}
+ */
+function mergeAttributes(value) {
+  if (!value) {
+    return {}
+  }
+  if (Array.isArray(value)) {
+    return Object.assign({}, ...value)
+  }
+  return value
+}
+
+/**
+ * @param {Record<string, unknown>} attributes
+ * @returns {string}
+ */
+function serializeAttributes(attributes) {
+  return Object.entries(attributes)
+    .flatMap(([name, value]) => {
+      if (value === false || value === null || value === undefined) {
+        return []
+      }
+      if (value === true) {
+        return [escapeAttributeName(name)]
+      }
+      return [`${escapeAttributeName(name)}="${escapeAttributeValue(String(value))}"`]
+    })
+    .join(' ')
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeAttributeName(value) {
+  return value.replace(/[^A-Za-z0-9_:-]/g, '')
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeAttributeValue(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}


### PR DESCRIPTION
## Summary

- Render `viewport`, `htmlAttributes`, and `bodyAttributes` from Vike config in SSR HTML.
- Add attribute serialization helpers with escaping and boolean/null handling.
- Document supported config output and update the minimal example.

Closes #19.

## Verification

- `pnpm run build`
- `pnpm run test` in `examples/minimal`
- `pnpm run build` in `examples/minimal`
- `pnpm run build` in `examples/full`
- `npm pack --dry-run --json` in `packages/vike-svelte`
- `git diff --check`