### PR TITLE
feat: compose cumulative layouts and wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ The renderer currently declares these Vike config entries:
 | `bodyAttributes` | Declared, renderer output tracked in [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
 | `onAfterRenderClient` | Declared for client runtime hooks |
 
+`Wrapper` entries render outside `Layout` entries. Cumulative entries compose in their resolved config order, then the page component renders at the center of the stack.
+
 ## 🧱 Parity With vike-react
 
 `vike-svelte` is not yet feature-equivalent with `vike-react`. The current work is split into executable issues:
@@ -129,7 +131,7 @@ The renderer currently declares these Vike config entries:
 | Public runtime hooks | [#17](https://github.com/brandonxiang/vike-svelte/issues/17) |
 | Dynamic head and config APIs | [#18](https://github.com/brandonxiang/vike-svelte/issues/18) |
 | Renderer output for declared config | [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
-| Cumulative `Layout` and `Wrapper` behavior | [#20](https://github.com/brandonxiang/vike-svelte/issues/20) |
+| Cumulative `Layout` and `Wrapper` behavior | Cumulative composition is supported. See [#20](https://github.com/brandonxiang/vike-svelte/issues/20) |
 | Streaming support decision | [#21](https://github.com/brandonxiang/vike-svelte/issues/21) |
 | Client-only static removal behavior | [#22](https://github.com/brandonxiang/vike-svelte/issues/22) |
 | Parity matrix and ecosystem examples | [#23](https://github.com/brandonxiang/vike-svelte/issues/23) |

--- a/packages/vike-svelte/README.md
+++ b/packages/vike-svelte/README.md
@@ -120,6 +120,8 @@ The renderer currently declares these Vike config entries:
 | `bodyAttributes` | Declared, renderer output tracked in [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
 | `onAfterRenderClient` | Declared for client runtime hooks |
 
+`Wrapper` entries render outside `Layout` entries. Cumulative entries compose in their resolved config order, then the page component renders at the center of the stack.
+
 ## 🧱 Parity With vike-react
 
 `vike-svelte` is not yet feature-equivalent with `vike-react`. The current work is split into executable issues:
@@ -129,7 +131,7 @@ The renderer currently declares these Vike config entries:
 | Public runtime hooks | [#17](https://github.com/brandonxiang/vike-svelte/issues/17) |
 | Dynamic head and config APIs | [#18](https://github.com/brandonxiang/vike-svelte/issues/18) |
 | Renderer output for declared config | [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
-| Cumulative `Layout` and `Wrapper` behavior | [#20](https://github.com/brandonxiang/vike-svelte/issues/20) |
+| Cumulative `Layout` and `Wrapper` behavior | Cumulative composition is supported. See [#20](https://github.com/brandonxiang/vike-svelte/issues/20) |
 | Streaming support decision | [#21](https://github.com/brandonxiang/vike-svelte/issues/21) |
 | Client-only static removal behavior | [#22](https://github.com/brandonxiang/vike-svelte/issues/22) |
 | Parity matrix and ecosystem examples | [#23](https://github.com/brandonxiang/vike-svelte/issues/23) |

--- a/packages/vike-svelte/components/RenderStack.svelte
+++ b/packages/vike-svelte/components/RenderStack.svelte
@@ -1,0 +1,39 @@
+<script>
+  import { getContext, setContext } from 'svelte'
+
+  const StackKey = 'vike-svelte:render-stack'
+  const IndexKey = 'vike-svelte:render-stack-index'
+
+  /**
+   * @typedef {Object} RenderStackState
+   * @property {import('svelte').Component[]} components
+   * @property {import('svelte').Component} Page
+   */
+
+  /**
+   * @typedef {Object} Props
+   * @property {import('svelte').Component[]} [components]
+   * @property {import('svelte').Component} [Page]
+   */
+
+  /** @type {Props} */
+  let { components, Page } = $props()
+
+  /** @type {RenderStackState | undefined} */
+  const parentStack = getContext(StackKey)
+  const stack = $derived.by(() => (components && Page ? { components, Page } : parentStack))
+  const index = getContext(IndexKey) ?? 0
+
+  // svelte-ignore state_referenced_locally
+  if (!stack) {
+    throw new Error('RenderStack requires components and Page props at the root')
+  }
+
+  // svelte-ignore state_referenced_locally
+  setContext(StackKey, stack)
+  setContext(IndexKey, index + 1)
+
+  const Component = $derived(stack.components[index] ?? stack.Page)
+</script>
+
+<Component Page={RenderStack} />

--- a/packages/vike-svelte/renderer/integration/onRenderClient.js
+++ b/packages/vike-svelte/renderer/integration/onRenderClient.js
@@ -1,13 +1,12 @@
 export { onRenderClient }
 
 import Empty from '../../components/Empty.svelte';
-import PassThrough from '../../components/PassThrough.svelte'
+import RenderStack from '../../components/RenderStack.svelte'
 import { PageKey } from '../utils/context.js'
+import { getComponentStack } from '../utils/componentStack.js'
 import { hydrate, mount, unmount } from 'svelte';
 
-/**
- * @type {null}
- */
+/** @type {ReturnType<typeof hydrate> | ReturnType<typeof mount> | null} */
 let root = null;
 
 let rendered = false;
@@ -25,9 +24,8 @@ function onRenderClient(pageContext) {
 
   /** @type {*} */
   const config = pageContext.config
-  /** @type {import('svelte').Component} */
-  const Layout = config.Layout?.[0] ?? PassThrough;
   const Page = pageContext.Page ?? Empty;
+  const components = getComponentStack(config, Page)
 
 
 
@@ -36,18 +34,20 @@ function onRenderClient(pageContext) {
     }
 
     if (pageContext.isHydration) {
-      root = hydrate(Layout, {
+      root = hydrate(RenderStack, {
         target,
         context: new Map([[PageKey, pageContext]]),
         props: {
+          components,
           Page,
         }
       });
     } else {
-      root = mount(Layout, {
+      root = mount(RenderStack, {
         target,
         context: new Map([[PageKey, pageContext]]),
         props: {
+          components,
           Page,
         }
       });

--- a/packages/vike-svelte/renderer/integration/onRenderHtml.js
+++ b/packages/vike-svelte/renderer/integration/onRenderHtml.js
@@ -2,10 +2,11 @@
 export { onRenderHtml }
 
 import { escapeInject, dangerouslySkipEscape } from 'vike/server'
-import PassThrough from '../../components/PassThrough.svelte'
+import RenderStack from '../../components/RenderStack.svelte'
 import Empty from '../../components/Empty.svelte'
 import { getTitle } from '../getTitle.js'
 import { PageKey } from '../utils/context.js'
+import { getComponentStack } from '../utils/componentStack.js'
 import { render } from 'svelte/server'
 
 /**
@@ -16,11 +17,13 @@ import { render } from 'svelte/server'
 function onRenderHtml(pageContext) {
   /** @type {*} */
   const config = pageContext.config
-  /** @type{*} */
-  const Layout = config.Layout?.[0] ?? PassThrough;
   const Page = pageContext.Page ?? Empty;
+  const components = getComponentStack(config, Page)
 
-  const app = render(Layout, { context: new Map([[PageKey, pageContext]]), props: { Page } })
+  const app = render(RenderStack, {
+    context: new Map([[PageKey, pageContext]]),
+    props: { components, Page },
+  })
   const { body, head } = app
 
   const title = getTitle(pageContext)

--- a/packages/vike-svelte/renderer/utils/componentStack.js
+++ b/packages/vike-svelte/renderer/utils/componentStack.js
@@ -1,0 +1,25 @@
+export { getComponentStack }
+
+/**
+ * @param {*} config
+ * @param {import('svelte').Component} Page
+ * @returns {import('svelte').Component[]}
+ */
+function getComponentStack(config, Page) {
+  return [
+    ...normalizeComponents(config.Wrapper),
+    ...normalizeComponents(config.Layout),
+    Page,
+  ]
+}
+
+/**
+ * @param {import('svelte').Component | import('svelte').Component[] | undefined} value
+ * @returns {import('svelte').Component[]}
+ */
+function normalizeComponents(value) {
+  if (!value) {
+    return []
+  }
+  return Array.isArray(value) ? value.filter(Boolean) : [value]
+}


### PR DESCRIPTION
## Summary

- Add a `RenderStack` component to compose cumulative `Wrapper` and `Layout` config entries.
- Apply the same component stack during SSR, hydration, and client navigation.
- Document composition order in the README files.

Closes #20.

## Verification

- `pnpm run build`
- `pnpm run test` in `examples/minimal`
- `pnpm run build` in `examples/minimal`
- `pnpm run build` in `examples/full`
- `npm pack --dry-run --json` in `packages/vike-svelte`
- `git diff --check`