### PR TITLE
docs: clarify streaming support status

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The renderer currently declares these Vike config entries:
 | `favicon` | Supported through renderer favicon output |
 | `lang` | Supported through `<html lang>` |
 | `ssr` | Supported through the renderer config effect |
-| `stream` | Declared, streaming decision tracked in [#21](https://github.com/brandonxiang/vike-svelte/issues/21) |
+| `stream` | Not supported yet; the renderer returns full Svelte `render()` output. See [#21](https://github.com/brandonxiang/vike-svelte/issues/21) |
 | `viewport` | Declared, renderer output tracked in [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
 | `htmlAttributes` | Declared, renderer output tracked in [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
 | `bodyAttributes` | Declared, renderer output tracked in [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
@@ -130,7 +130,7 @@ The renderer currently declares these Vike config entries:
 | Dynamic head and config APIs | [#18](https://github.com/brandonxiang/vike-svelte/issues/18) |
 | Renderer output for declared config | [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
 | Cumulative `Layout` and `Wrapper` behavior | [#20](https://github.com/brandonxiang/vike-svelte/issues/20) |
-| Streaming support decision | [#21](https://github.com/brandonxiang/vike-svelte/issues/21) |
+| Streaming support decision | Streaming is intentionally deferred. See [#21](https://github.com/brandonxiang/vike-svelte/issues/21) |
 | Client-only static removal behavior | [#22](https://github.com/brandonxiang/vike-svelte/issues/22) |
 | Parity matrix and ecosystem examples | [#23](https://github.com/brandonxiang/vike-svelte/issues/23) |
 

--- a/packages/vike-svelte/README.md
+++ b/packages/vike-svelte/README.md
@@ -114,7 +114,7 @@ The renderer currently declares these Vike config entries:
 | `favicon` | Supported through renderer favicon output |
 | `lang` | Supported through `<html lang>` |
 | `ssr` | Supported through the renderer config effect |
-| `stream` | Declared, streaming decision tracked in [#21](https://github.com/brandonxiang/vike-svelte/issues/21) |
+| `stream` | Not supported yet; the renderer returns full Svelte `render()` output. See [#21](https://github.com/brandonxiang/vike-svelte/issues/21) |
 | `viewport` | Declared, renderer output tracked in [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
 | `htmlAttributes` | Declared, renderer output tracked in [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
 | `bodyAttributes` | Declared, renderer output tracked in [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
@@ -130,7 +130,7 @@ The renderer currently declares these Vike config entries:
 | Dynamic head and config APIs | [#18](https://github.com/brandonxiang/vike-svelte/issues/18) |
 | Renderer output for declared config | [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
 | Cumulative `Layout` and `Wrapper` behavior | [#20](https://github.com/brandonxiang/vike-svelte/issues/20) |
-| Streaming support decision | [#21](https://github.com/brandonxiang/vike-svelte/issues/21) |
+| Streaming support decision | Streaming is intentionally deferred. See [#21](https://github.com/brandonxiang/vike-svelte/issues/21) |
 | Client-only static removal behavior | [#22](https://github.com/brandonxiang/vike-svelte/issues/22) |
 | Parity matrix and ecosystem examples | [#23](https://github.com/brandonxiang/vike-svelte/issues/23) |
 

--- a/packages/vike-svelte/renderer/+config.js
+++ b/packages/vike-svelte/renderer/+config.js
@@ -54,9 +54,6 @@ export default {
       env: { config: true },
       effect: ssrEffect,
     },
-    stream: {
-      env: { server: true },
-    },
     htmlAttributes: {
       env: { server: true },
       global: true,

--- a/packages/vike-svelte/renderer/types.d.ts
+++ b/packages/vike-svelte/renderer/types.d.ts
@@ -39,6 +39,11 @@ declare global {
        *
        */
       ssr?: boolean
+      /**
+       * Streaming is not supported yet. The current renderer uses Svelte's full
+       * `render()` output and returns a complete HTML document.
+       */
+      stream?: never
     }
   }
 }
@@ -75,6 +80,11 @@ declare global {
        *
        */
       ssr?: boolean
+      /**
+       * Streaming is not supported yet. The current renderer uses Svelte's full
+       * `render()` output and returns a complete HTML document.
+       */
+      stream?: never
     }
   }
 }


### PR DESCRIPTION
## Summary

- Remove the `stream` config meta entry because the current renderer returns full Svelte `render()` output.
- Mark `stream` as unsupported in TypeScript config types.
- Document the deferred streaming status in both README files.

Closes #21.

## Verification

- `pnpm run build`
- `pnpm run build` in `examples/minimal`
- `git diff --check`