### PR TITLE
docs: define ClientOnly behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Use `vike-svelte/clientOnly` when a component depends on browser APIs and should
 
 The current API uses `target`, `componentProps`, and `fallback`. Client-only parity with `vike-react` is tracked in [issue #22](https://github.com/brandonxiang/vike-svelte/issues/22).
 
+On the server, `ClientOnly` renders only the fallback component. If no fallback is provided, it renders nothing. The browser-only target component is mounted on the client, which avoids rendering browser API usage during SSR. `vike-svelte` does not currently implement React-style static replacement or compile-time tree-shaking for the target component.
+
 ## ⚙️ Supported Config
 
 The renderer currently declares these Vike config entries:
@@ -131,7 +133,7 @@ The renderer currently declares these Vike config entries:
 | Renderer output for declared config | [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
 | Cumulative `Layout` and `Wrapper` behavior | [#20](https://github.com/brandonxiang/vike-svelte/issues/20) |
 | Streaming support decision | [#21](https://github.com/brandonxiang/vike-svelte/issues/21) |
-| Client-only static removal behavior | [#22](https://github.com/brandonxiang/vike-svelte/issues/22) |
+| Client-only static removal behavior | Runtime fallback behavior is documented; static replacement is not supported. See [#22](https://github.com/brandonxiang/vike-svelte/issues/22) |
 | Parity matrix and ecosystem examples | [#23](https://github.com/brandonxiang/vike-svelte/issues/23) |
 
 The original audit is available in [issue #16](https://github.com/brandonxiang/vike-svelte/issues/16).

--- a/examples/full/pages/client-only/+Page.svelte
+++ b/examples/full/pages/client-only/+Page.svelte
@@ -2,7 +2,9 @@
 <script>
   import ClientOnly from 'vike-svelte/clientOnly';
   import ClientHelloWorld  from './ClientHelloWorld.svelte';
+  import BrowserViewport from './BrowserViewport.svelte';
   import Fallback from './Fallback.svelte';
 </script>
 
 <ClientOnly target={ClientHelloWorld} componentProps={{name: 'brandon'}} fallback={Fallback} />
+<ClientOnly target={BrowserViewport} fallback={Fallback} />

--- a/examples/full/pages/client-only/BrowserViewport.svelte
+++ b/examples/full/pages/client-only/BrowserViewport.svelte
@@ -1,0 +1,11 @@
+<script>
+  import { onMount } from 'svelte'
+
+  let width = $state(0)
+
+  onMount(() => {
+    width = window.innerWidth
+  })
+</script>
+
+<div>Browser viewport width: {width}px</div>

--- a/packages/vike-svelte/README.md
+++ b/packages/vike-svelte/README.md
@@ -100,6 +100,8 @@ Use `vike-svelte/clientOnly` when a component depends on browser APIs and should
 
 The current API uses `target`, `componentProps`, and `fallback`. Client-only parity with `vike-react` is tracked in [issue #22](https://github.com/brandonxiang/vike-svelte/issues/22).
 
+On the server, `ClientOnly` renders only the fallback component. If no fallback is provided, it renders nothing. The browser-only target component is mounted on the client, which avoids rendering browser API usage during SSR. `vike-svelte` does not currently implement React-style static replacement or compile-time tree-shaking for the target component.
+
 ## ⚙️ Supported Config
 
 The renderer currently declares these Vike config entries:
@@ -131,7 +133,7 @@ The renderer currently declares these Vike config entries:
 | Renderer output for declared config | [#19](https://github.com/brandonxiang/vike-svelte/issues/19) |
 | Cumulative `Layout` and `Wrapper` behavior | [#20](https://github.com/brandonxiang/vike-svelte/issues/20) |
 | Streaming support decision | [#21](https://github.com/brandonxiang/vike-svelte/issues/21) |
-| Client-only static removal behavior | [#22](https://github.com/brandonxiang/vike-svelte/issues/22) |
+| Client-only static removal behavior | Runtime fallback behavior is documented; static replacement is not supported. See [#22](https://github.com/brandonxiang/vike-svelte/issues/22) |
 | Parity matrix and ecosystem examples | [#23](https://github.com/brandonxiang/vike-svelte/issues/23) |
 
 The original audit is available in [issue #16](https://github.com/brandonxiang/vike-svelte/issues/16).

--- a/packages/vike-svelte/components/ClientOnly.svelte
+++ b/packages/vike-svelte/components/ClientOnly.svelte
@@ -3,25 +3,20 @@
 
   /**
    * @typedef {Object} Props
-   * @property {import('svelte').SvelteComponent } target
-   * @property {*} componentProps
-   * @property {import('svelte').SvelteComponent | undefined } fallback
+   * @property {import('svelte').Component } target
+   * @property {*} [componentProps]
+   * @property {import('svelte').Component | undefined } [fallback]
    */
 
   /** @type {Props} */
-  let { target, componentProps, fallback } = $props()
+  let { target, componentProps = {}, fallback } = $props()
 
-  const ComponentConstructor = $derived(BROWSER ? target : new Promise(() => {}))
+  const TargetComponent = $derived(BROWSER ? target : undefined)
+  const FallbackComponent = $derived(fallback)
 </script>
 
-{#await ComponentConstructor}
-  {#if fallback}
-    <fallback {...componentProps}></fallback>
-  {:else}
-    <p>Loading...</p>
-  {/if}
-{:then TargetComponent}
+{#if TargetComponent}
   <TargetComponent {...componentProps}></TargetComponent>
-{:catch error}
-  <p>Something went wrong: {error.message}</p>
-{/await}
+{:else if FallbackComponent}
+  <FallbackComponent {...componentProps}></FallbackComponent>
+{/if}


### PR DESCRIPTION
## Summary

- Document `ClientOnly` SSR/client behavior and the current static replacement limitation.
- Render no default loading markup when no fallback is supplied, keeping SSR output free of browser-only target content.
- Add a browser API example that renders through `ClientOnly`.

Closes #22.

## Verification

- `pnpm run build`
- `pnpm run test` in `examples/full`
- `pnpm run build` in `examples/full`
- `npm pack --dry-run --json` in `packages/vike-svelte`
- `git diff --check`