### PR TITLE
fix(components): resolve RenderStack is not defined error

### DIFF
--- a/packages/vike-svelte/components/RenderStack.svelte
+++ b/packages/vike-svelte/components/RenderStack.svelte
@@ -1,5 +1,6 @@
 <script>
   import { getContext, setContext } from 'svelte'
+  import RenderStackSelf from './RenderStack.svelte'
 
   const StackKey = 'vike-svelte:render-stack'
   const IndexKey = 'vike-svelte:render-stack-index'
@@ -36,4 +37,4 @@
   const Component = $derived(stack.components[index] ?? stack.Page)
 </script>
 
-<Component Page={RenderStack} />
+<Component Page={RenderStackSelf} />


### PR DESCRIPTION
Hey!

## Changes
- Resolves #31 
- I did rename the import to make it more obvious of the recursion.

******


## Test Status
No new tests added
All tests currently pass

Manual tests via `dev` and `preview` confirms issue is resolved, Svelte hydrates, and signal interactivity etc..
Will need to add playwright for e2e testing


******

edits:
the previous references to an issue with `+Wrapper` is solved.
It was a knowledge issue, will update the docs.